### PR TITLE
feat: add shipping address form and page

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@auth/prisma-adapter": "^2.7.4",
+    "@hookform/resolvers": "^5.0.1",
     "@neondatabase/serverless": "^0.10.4",
     "@prisma/adapter-neon": "^6.3.1",
     "@radix-ui/react-avatar": "^1.1.3",
@@ -29,6 +30,7 @@
     "next-themes": "^0.4.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-hook-form": "^7.56.4",
     "react-use": "^17.6.0",
     "tailwind-merge": "^3.0.1",
     "tailwindcss-animate": "^1.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@auth/prisma-adapter':
         specifier: ^2.7.4
         version: 2.7.4(@prisma/client@6.3.1(prisma@6.3.1(typescript@5.7.3))(typescript@5.7.3))
+      '@hookform/resolvers':
+        specifier: ^5.0.1
+        version: 5.0.1(react-hook-form@7.56.4(react@19.0.0))
       '@neondatabase/serverless':
         specifier: ^0.10.4
         version: 0.10.4
@@ -65,6 +68,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.0.0(react@19.0.0)
+      react-hook-form:
+        specifier: ^7.56.4
+        version: 7.56.4(react@19.0.0)
       react-use:
         specifier: ^17.6.0
         version: 17.6.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -218,6 +224,11 @@ packages:
 
   '@floating-ui/utils@0.2.9':
     resolution: {integrity: sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==}
+
+  '@hookform/resolvers@5.0.1':
+    resolution: {integrity: sha512-u/+Jp83luQNx9AdyW2fIPGY6Y7NG68eN2ZW8FOJYL+M0i4s49+refdJdOp/A9n9HFQtQs3HIDHQvX3ZET2o7YA==}
+    peerDependencies:
+      react-hook-form: ^7.55.0
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -874,6 +885,9 @@ packages:
 
   '@rushstack/eslint-patch@1.10.5':
     resolution: {integrity: sha512-kkKUDVlII2DQiKy7UstOR1ErJP8kUKAQ4oa+SQtM0K+lPdmmjj0YnnxBgtTVYH7mUKtbsxeFC9y0AmK7Yb78/A==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
@@ -2109,6 +2123,12 @@ packages:
     peerDependencies:
       react: ^19.0.0
 
+  react-hook-form@7.56.4:
+    resolution: {integrity: sha512-Rob7Ftz2vyZ/ZGsQZPaRdIefkgOSrQSPXfqBdvOPwJfoGnjwRJUs7EM7Kc1mcoDv3NOtqBzPGbcMB8CGn9CKgw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
+
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
@@ -2657,6 +2677,11 @@ snapshots:
       react-dom: 19.0.0(react@19.0.0)
 
   '@floating-ui/utils@0.2.9': {}
+
+  '@hookform/resolvers@5.0.1(react-hook-form@7.56.4(react@19.0.0))':
+    dependencies:
+      '@standard-schema/utils': 0.3.0
+      react-hook-form: 7.56.4(react@19.0.0)
 
   '@humanfs/core@0.19.1': {}
 
@@ -3222,6 +3247,8 @@ snapshots:
   '@rtsao/scc@1.1.0': {}
 
   '@rushstack/eslint-patch@1.10.5': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@swc/counter@0.1.3': {}
 
@@ -4632,6 +4659,10 @@ snapshots:
     dependencies:
       react: 19.0.0
       scheduler: 0.25.0
+
+  react-hook-form@7.56.4(react@19.0.0):
+    dependencies:
+      react: 19.0.0
 
   react-is@16.13.1: {}
 

--- a/src/app/(main)/cart/CartTable.tsx
+++ b/src/app/(main)/cart/CartTable.tsx
@@ -12,14 +12,22 @@ import { useToast } from '@/lib/hooks/use-toast';
 import { Cart } from '@/lib/types';
 import Link from 'next/link';
 import Image from 'next/image';
-// import { useRouter } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 import { useTransition } from 'react';
 import { Button } from '@/lib/components/ui/button';
 import { addItemToCart, removeItemFromCart } from '@/lib/actions';
-import { Minus, Plus } from 'lucide-react';
+import { ArrowRight, Loader, Minus, Plus } from 'lucide-react';
+import { Card, CardContent } from '@/lib/components/ui/card';
+import { formatCurrency } from '@/lib/utils';
 
-const CartTable = ({ items }: { items?: Cart['items'] }) => {
-  // const router = useRouter();
+const CartTable = ({
+  items,
+  itemsPrice,
+}: {
+  items?: Cart['items'];
+  itemsPrice?: number;
+}) => {
+  const router = useRouter();
   const { toast } = useToast();
   const [isPending, startTransition] = useTransition();
 
@@ -105,6 +113,28 @@ const CartTable = ({ items }: { items?: Cart['items'] }) => {
               </TableBody>
             </Table>
           </div>
+          <Card>
+            <CardContent className="p-4 gap-4">
+              <div className="pb-3 text-xl">
+                Subtotal ({items.reduce((a, c) => a + c.quantity, 0)}):
+                <span className="font-bold">{formatCurrency(itemsPrice)}</span>
+              </div>
+              <Button
+                onClick={() =>
+                  startTransition(() => router.push('/shipping-address'))
+                }
+                className="w-full"
+                disabled={isPending}
+              >
+                {isPending ? (
+                  <Loader className="animate-spin w-4 h-4" />
+                ) : (
+                  <ArrowRight className="w-4 h-4" />
+                )}
+                Proceed to Checkout
+              </Button>
+            </CardContent>
+          </Card>
         </div>
       )}
     </>

--- a/src/app/(main)/cart/page.tsx
+++ b/src/app/(main)/cart/page.tsx
@@ -9,7 +9,7 @@ const CartPage = async () => {
   const cart = await getMyCart();
 
   return (
-    <CartTable items={cart?.items} />
+    <CartTable items={cart?.items} itemsPrice={cart?.itemsPrice} />
   )
 }
 export default CartPage

--- a/src/app/(main)/shipping-address/ShippingAddressForm.tsx
+++ b/src/app/(main)/shipping-address/ShippingAddressForm.tsx
@@ -103,11 +103,6 @@ const ShippingAddressForm = ({
                 name="streetAddress"
                 render={({
                   field,
-                }: {
-                  field: ControllerRenderProps<
-                    ShippingAddress,
-                    'streetAddress'
-                  >;
                 }) => (
                   <FormItem className="w-full">
                     <FormLabel>Address</FormLabel>
@@ -125,8 +120,6 @@ const ShippingAddressForm = ({
                 name="city"
                 render={({
                   field,
-                }: {
-                  field: ControllerRenderProps<ShippingAddress, 'city'>;
                 }) => (
                   <FormItem className="w-full">
                     <FormLabel>City</FormLabel>
@@ -142,8 +135,6 @@ const ShippingAddressForm = ({
                 name="country"
                 render={({
                   field,
-                }: {
-                  field: ControllerRenderProps<ShippingAddress, 'country'>;
                 }) => (
                   <FormItem className="w-full">
                     <FormLabel>Country</FormLabel>
@@ -159,8 +150,6 @@ const ShippingAddressForm = ({
                 name="postalCode"
                 render={({
                   field,
-                }: {
-                  field: ControllerRenderProps<ShippingAddress, 'postalCode'>;
                 }) => (
                   <FormItem className="w-full">
                     <FormLabel>Postal Code</FormLabel>

--- a/src/app/(main)/shipping-address/ShippingAddressForm.tsx
+++ b/src/app/(main)/shipping-address/ShippingAddressForm.tsx
@@ -6,7 +6,7 @@ import { useRouter } from 'next/navigation';
 import { ControllerRenderProps, SubmitHandler, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { shippingAddressSchema } from '@/lib/validators';
-import { startTransition, useTransition } from 'react';
+import { useTransition } from 'react';
 import {
   Form,
   FormControl,
@@ -39,7 +39,7 @@ const ShippingAddressForm = ({
 
   const [
     isPending,
-    // startTransition
+    startTransition
   ] = useTransition();
 
   const form = useForm<ShippingAddress>({

--- a/src/app/(main)/shipping-address/ShippingAddressForm.tsx
+++ b/src/app/(main)/shipping-address/ShippingAddressForm.tsx
@@ -22,11 +22,11 @@ import { updateUserAddress } from '@/lib/actions';
 // import { z } from 'zod';
 
 const shippingAddressDefaultValues: ShippingAddress = {
-  fullName: 'John Doe',
-  streetAddress: '123 Main St',
-  city: 'Anytown',
-  postalCode: '12345',
-  country: 'USA',
+  fullName: '',
+  streetAddress: '',
+  city: '',
+  postalCode: '',
+  country: '',
 };
 
 const ShippingAddressForm = ({

--- a/src/app/(main)/shipping-address/ShippingAddressForm.tsx
+++ b/src/app/(main)/shipping-address/ShippingAddressForm.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+import { useToast } from '@/lib/hooks/use-toast';
+import { ShippingAddress } from '@/lib/types';
+import { useRouter } from 'next/navigation';
+import { ControllerRenderProps, SubmitHandler, useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { shippingAddressSchema } from '@/lib/validators';
+import { startTransition, useTransition } from 'react';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/lib/components/ui/form';
+import { Button } from '@/lib/components/ui/button';
+import { Input } from '@/lib/components/ui/input';
+import { Loader, ArrowRight } from 'lucide-react';
+import { updateUserAddress } from '@/lib/actions';
+// import { z } from 'zod';
+
+const shippingAddressDefaultValues: ShippingAddress = {
+  fullName: 'John Doe',
+  streetAddress: '123 Main St',
+  city: 'Anytown',
+  postalCode: '12345',
+  country: 'USA',
+};
+
+const ShippingAddressForm = ({
+  address,
+}: {
+  address: ShippingAddress | null;
+}) => {
+  const router = useRouter();
+  const { toast } = useToast();
+
+  const [
+    isPending,
+    // startTransition
+  ] = useTransition();
+
+  const form = useForm<ShippingAddress>({
+    resolver: zodResolver(shippingAddressSchema),
+    defaultValues: address || shippingAddressDefaultValues,
+  });
+
+  const onSubmit: SubmitHandler<ShippingAddress> = (values) => {
+    startTransition(async () => {
+      const res = await updateUserAddress(values);
+      if (!res.success) {
+        toast({
+          variant: 'destructive',
+          description: res.message
+        });
+      } else {
+        router.push('/payment-method')
+      }
+    })
+  };
+
+  return (
+    <>
+      <div className="max-w-md mx-auto space-y-4">
+        <h1 className="h2-bold mt-4">Shipping Address</h1>
+        <p className="text-sm text-muted-foreground">
+          Please enter the address that you want to ship to
+        </p>
+        <Form {...form}>
+          <form
+            method="post"
+            onSubmit={form.handleSubmit(onSubmit)}
+            className="space-y-4"
+          >
+            <div className="flex flex-col gap-5 md:flex-row">
+              <FormField
+                control={form.control}
+                name="fullName"
+                render={({
+                  field,
+                }: {
+                  field: ControllerRenderProps<ShippingAddress, 'fullName'>;
+                }) => (
+                  <FormItem className="w-full">
+                    <FormLabel htmlFor={field.name}>Full Name</FormLabel>
+                    <FormControl>
+                      <Input
+                        {...field}
+                        id={field.name}
+                        placeholder="Enter full name"
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+            <div>
+              <FormField
+                control={form.control}
+                name="streetAddress"
+                render={({
+                  field,
+                }: {
+                  field: ControllerRenderProps<
+                    ShippingAddress,
+                    'streetAddress'
+                  >;
+                }) => (
+                  <FormItem className="w-full">
+                    <FormLabel>Address</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Enter address" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+            <div className="flex flex-col gap-5 md:flex-row">
+              <FormField
+                control={form.control}
+                name="city"
+                render={({
+                  field,
+                }: {
+                  field: ControllerRenderProps<ShippingAddress, 'city'>;
+                }) => (
+                  <FormItem className="w-full">
+                    <FormLabel>City</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Enter city" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="country"
+                render={({
+                  field,
+                }: {
+                  field: ControllerRenderProps<ShippingAddress, 'country'>;
+                }) => (
+                  <FormItem className="w-full">
+                    <FormLabel>Country</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Enter country" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="postalCode"
+                render={({
+                  field,
+                }: {
+                  field: ControllerRenderProps<ShippingAddress, 'postalCode'>;
+                }) => (
+                  <FormItem className="w-full">
+                    <FormLabel>Postal Code</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Enter postal code" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+            <div className="flex gap-2">
+              <Button type="submit" disabled={isPending}>
+                {isPending ? (
+                  <Loader className="animate-spin w-4 h-4" />
+                ) : (
+                  <ArrowRight className="w-4 h-4" />
+                )}
+                Continue
+              </Button>
+            </div>
+          </form>
+        </Form>
+      </div>
+    </>
+  );
+};
+
+export default ShippingAddressForm;

--- a/src/app/(main)/shipping-address/page.tsx
+++ b/src/app/(main)/shipping-address/page.tsx
@@ -1,0 +1,30 @@
+import { auth } from '@/auth';
+import { getMyCart, getUserById } from '@/lib/queries';
+import { Metadata } from 'next';
+import { redirect } from 'next/navigation';
+import ShippingAddressForm from './ShippingAddressForm';
+
+export const metadata: Metadata = {
+  title: 'Shipping Address',
+};
+
+const ShippingAddressPage = async () => {
+  const cart = await getMyCart();
+  if (!cart || cart.items.length === 0) redirect('/cart');
+
+  const session = await auth();
+  const userId = session?.user?.id;
+  if (!userId) {
+    throw new Error('User ID not found');
+  }
+
+  const user = await getUserById(userId);
+
+  return (
+    <>
+      <ShippingAddressForm address={user.address} />
+    </>
+  );
+};
+
+export default ShippingAddressPage;

--- a/src/app/(main)/shipping-address/page.tsx
+++ b/src/app/(main)/shipping-address/page.tsx
@@ -15,7 +15,7 @@ const ShippingAddressPage = async () => {
   const session = await auth();
   const userId = session?.user?.id;
   if (!userId) {
-    throw new Error('User ID not found');
+    return redirect('/sign-in?callbackUrl=/shipping-address');
   }
 
   const user = await getUserById(userId);

--- a/src/lib/components/ui/form.tsx
+++ b/src/lib/components/ui/form.tsx
@@ -1,0 +1,178 @@
+"use client"
+
+import * as React from "react"
+import * as LabelPrimitive from "@radix-ui/react-label"
+import { Slot } from "@radix-ui/react-slot"
+import {
+  Controller,
+  FormProvider,
+  useFormContext,
+  type ControllerProps,
+  type FieldPath,
+  type FieldValues,
+} from "react-hook-form"
+
+import { cn } from "@/lib/utils"
+import { Label } from "@/lib/components/ui/label"
+
+const Form = FormProvider
+
+type FormFieldContextValue<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+> = {
+  name: TName
+}
+
+const FormFieldContext = React.createContext<FormFieldContextValue>(
+  {} as FormFieldContextValue
+)
+
+const FormField = <
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+>({
+  ...props
+}: ControllerProps<TFieldValues, TName>) => {
+  return (
+    <FormFieldContext.Provider value={{ name: props.name }}>
+      <Controller {...props} />
+    </FormFieldContext.Provider>
+  )
+}
+
+const useFormField = () => {
+  const fieldContext = React.useContext(FormFieldContext)
+  const itemContext = React.useContext(FormItemContext)
+  const { getFieldState, formState } = useFormContext()
+
+  const fieldState = getFieldState(fieldContext.name, formState)
+
+  if (!fieldContext) {
+    throw new Error("useFormField should be used within <FormField>")
+  }
+
+  const { id } = itemContext
+
+  return {
+    id,
+    name: fieldContext.name,
+    formItemId: `${id}-form-item`,
+    formDescriptionId: `${id}-form-item-description`,
+    formMessageId: `${id}-form-item-message`,
+    ...fieldState,
+  }
+}
+
+type FormItemContextValue = {
+  id: string
+}
+
+const FormItemContext = React.createContext<FormItemContextValue>(
+  {} as FormItemContextValue
+)
+
+const FormItem = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+  const id = React.useId()
+
+  return (
+    <FormItemContext.Provider value={{ id }}>
+      <div ref={ref} className={cn("space-y-2", className)} {...props} />
+    </FormItemContext.Provider>
+  )
+})
+FormItem.displayName = "FormItem"
+
+const FormLabel = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>
+>(({ className, ...props }, ref) => {
+  const { error, formItemId } = useFormField()
+
+  return (
+    <Label
+      ref={ref}
+      className={cn(error && "text-destructive", className)}
+      htmlFor={formItemId}
+      {...props}
+    />
+  )
+})
+FormLabel.displayName = "FormLabel"
+
+const FormControl = React.forwardRef<
+  React.ElementRef<typeof Slot>,
+  React.ComponentPropsWithoutRef<typeof Slot>
+>(({ ...props }, ref) => {
+  const { error, formItemId, formDescriptionId, formMessageId } = useFormField()
+
+  return (
+    <Slot
+      ref={ref}
+      id={formItemId}
+      aria-describedby={
+        !error
+          ? `${formDescriptionId}`
+          : `${formDescriptionId} ${formMessageId}`
+      }
+      aria-invalid={!!error}
+      {...props}
+    />
+  )
+})
+FormControl.displayName = "FormControl"
+
+const FormDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => {
+  const { formDescriptionId } = useFormField()
+
+  return (
+    <p
+      ref={ref}
+      id={formDescriptionId}
+      className={cn("text-[0.8rem] text-muted-foreground", className)}
+      {...props}
+    />
+  )
+})
+FormDescription.displayName = "FormDescription"
+
+const FormMessage = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, children, ...props }, ref) => {
+  const { error, formMessageId } = useFormField()
+  const body = error ? String(error?.message ?? "") : children
+
+  if (!body) {
+    return null
+  }
+
+  return (
+    <p
+      ref={ref}
+      id={formMessageId}
+      className={cn("text-[0.8rem] font-medium text-destructive", className)}
+      {...props}
+    >
+      {body}
+    </p>
+  )
+})
+FormMessage.displayName = "FormMessage"
+
+export {
+  useFormField,
+  Form,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormDescription,
+  FormMessage,
+  FormField,
+}

--- a/src/lib/data/client.ts
+++ b/src/lib/data/client.ts
@@ -2,7 +2,7 @@ import { Pool, neonConfig } from '@neondatabase/serverless';
 import { PrismaNeon } from '@prisma/adapter-neon';
 import { PrismaClient } from '@prisma/client';
 import ws from 'ws';
-import { CartItem } from '../types';
+import { CartItem, ShippingAddress } from '../types';
 
 // Sets up WebSocket connections, which enables Neon to use WebSocket communication.
 neonConfig.webSocketConstructor = ws;
@@ -17,6 +17,18 @@ const adapter = new PrismaNeon(pool);
 // Extends the PrismaClient with a custom result transformer to convert the price and rating fields to strings.
 export const prisma = new PrismaClient({ adapter }).$extends({
   result: {
+    user: {
+      address: {
+        compute(user) {
+          // TODO: Refactor to store address in a separate table instead of JSON
+          return (
+            typeof user.address === 'string'
+              ? JSON.parse(user.address)
+              : user.address
+          ) as ShippingAddress;
+        },
+      },
+    },
     product: {
       price: {
         compute(product) {

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -4,6 +4,8 @@ import { User } from 'next-auth';
 import { cookies } from 'next/headers';
 import { auth } from '@/auth';
 
+// Product queries
+// -------------------------------------------------------------
 export const getLatestProducts = async (limit?: number) => {
   return prisma.product.findMany({
     orderBy: {
@@ -21,6 +23,8 @@ export const getProductById = async (id: Product['id']) => {
   return prisma.product.findFirst({ where: { id } });
 };
 
+// User queries
+// -------------------------------------------------------------
 export const getUserByEmail = async (email: User['email']) => {
   if (!email) {
     return null;
@@ -33,6 +37,20 @@ export const getUserByEmail = async (email: User['email']) => {
   });
 };
 
+export const getUserById = async (id: User['id']) => {
+  const user = await prisma.user.findFirst({
+    where: { id },
+  });
+
+  if (!user) {
+    throw new Error('User not found');
+  }
+
+  return user;
+};
+
+// Cart queries
+// -------------------------------------------------------------
 export const getMyCart = async () => {
   // Check for cart cookie
   const sessionCartId = (await cookies()).get('sessionCartId')?.value;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -7,6 +7,9 @@ import {
   shippingAddressSchema,
 } from './validators';
 
+/**********************************************************************
+ * Prisma Types for Models
+ **********************************************************************/
 export type Product = Prisma.Result<
   typeof prisma.product,
   null,
@@ -14,9 +17,24 @@ export type Product = Prisma.Result<
 >;
 export type User = Prisma.Result<typeof prisma.user, null, 'findFirstOrThrow'>;
 export type Cart = Prisma.Result<typeof prisma.cart, null, 'findFirstOrThrow'>;
+
+/**********************************************************************
+ * Zod Types for Validation or Interfaces
+ * - These types are used for validating data structures before they are sent to the database or used in the application.
+ * - They ensure that the data conforms to the expected format. (These types are not come from Prisma, so that this can cause issues if Prisma models or Zod schema changes.)
+ **********************************************************************/
 export type CartItem = z.infer<typeof cartItemSchema>;
 export type InsertCart = z.infer<typeof insertCartSchema>;
 export type ShippingAddress = z.infer<typeof shippingAddressSchema>;
+
+/**********************************************************************
+ * Request and Response Types
+ **********************************************************************/
+export type ActionResult<T = void> = {
+  success: boolean;
+  message?: string;
+  data?: T;
+};
 
 /**********************************************************************
  * Authentication

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,7 +1,11 @@
 import { z } from 'zod';
 import { Prisma } from '@prisma/client';
 import { prisma } from './data/client';
-import { cartItemSchema, insertCartSchema } from './validators';
+import {
+  cartItemSchema,
+  insertCartSchema,
+  shippingAddressSchema,
+} from './validators';
 
 export type Product = Prisma.Result<
   typeof prisma.product,
@@ -12,6 +16,7 @@ export type User = Prisma.Result<typeof prisma.user, null, 'findFirstOrThrow'>;
 export type Cart = Prisma.Result<typeof prisma.cart, null, 'findFirstOrThrow'>;
 export type CartItem = z.infer<typeof cartItemSchema>;
 export type InsertCart = z.infer<typeof insertCartSchema>;
+export type ShippingAddress = z.infer<typeof shippingAddressSchema>;
 
 /**********************************************************************
  * Authentication

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -108,6 +108,6 @@ export function formatCurrency(amount?: number | string): string {
   } else if (typeof amount === 'number') {
     return currencyFormatter.format(amount);
   } else {
-    return 'NaN';
+    return currencyFormatter.format(0);
   }
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -95,3 +95,19 @@ export function calcPrice(items: CartItem[]) {
     totalPrice,
   };
 }
+
+const currencyFormatter = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  minimumFractionDigits: 2,
+});
+
+export function formatCurrency(amount?: number | string): string {
+  if (typeof amount === 'string') {
+    return currencyFormatter.format(Number(amount));
+  } else if (typeof amount === 'number') {
+    return currencyFormatter.format(amount);
+  } else {
+    return 'NaN';
+  }
+}

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -23,8 +23,11 @@ export const insertProductSchema = z.object({
 });
 
 const credentialsSchema = z.object({
-  email: z.string({ required_error: 'Email is required' }).email('Invalid email'),
-  password: z.string({ required_error: 'Password is required' })
+  email: z
+    .string({ required_error: 'Email is required' })
+    .email('Invalid email'),
+  password: z
+    .string({ required_error: 'Password is required' })
     .min(6, 'Password must be more than 6 characters')
     .max(32, 'Password must be less than 32 characters'),
 });
@@ -47,7 +50,7 @@ export const cartItemSchema = z.object({
   slug: z.string().min(1, 'Slug is required'),
   quantity: z.number().int().nonnegative('Quantity must be a positive integer'),
   image: z.string().min(1, 'Image is required'),
-  price: currency
+  price: currency,
 });
 
 export const insertCartSchema = z.object({
@@ -58,4 +61,14 @@ export const insertCartSchema = z.object({
   taxPrice: currency,
   sessionCartId: z.string().min(1, 'Session card ID is required'),
   userId: z.string().optional().nullable(),
+});
+
+export const shippingAddressSchema = z.object({
+  fullName: z.string().min(3, 'Name must be at least 3 characters'),
+  streetAddress: z.string().min(3, 'Address must be at least 3 characters'),
+  city: z.string().min(2, 'City must be at least 2 characters'),
+  postalCode: z.string().min(3, 'Postal code must be at least 3 characters'),
+  country: z.string().min(1, 'Country is required'),
+  lat: z.number().optional(),
+  lng: z.number().optional(),
 });


### PR DESCRIPTION
## Add Shipping Address Form

### Summary

- Refactored the `ActionResult` type to default to `void`, simplifying its usage across the codebase.
- Updated all action functions in `actions.ts` to use the improved `ActionResult` type without explicitly specifying `null` or `undefined`.
- Added a shipping address page, form, related action, and schema for handling user shipping addresses.

### Details

- `ActionResult` Type Changes:
  - Defaulted the generic type to `void` for cleaner and more intuitive usage.
  - Ensures that actions returning no data do not require unnecessary type arguments.

- Shipping Address Page and Form:
  - Created a new `ShippingAddressPage` in `src/app/(main)/shipping-address/page.tsx`.
  - Added a `ShippingAddressForm` component for users to input their shipping details.

- Related Action and Schema:
  - Added an action in `actions.ts` to handle shipping address updates.
  - Defined a schema in `validators.ts` for validating shipping address data.
